### PR TITLE
chore: enforce Google-style docstrings

### DIFF
--- a/powerplay_app/admin.py
+++ b/powerplay_app/admin.py
@@ -88,6 +88,14 @@ for model in (
 def regenerate_calendar_events(modeladmin: Any, request: Any, queryset: Any) -> None:
     """Re-sync calendar events for selected games.
 
+    Args:
+        modeladmin: Django admin interface instance.
+        request: Current HTTP request.
+        queryset: Games selected for resynchronization.
+
+    Returns:
+        None
+
     Notes:
         UI text remains Czech; action reuses the app's sync helper.
     """
@@ -111,7 +119,15 @@ class LeagueAdmin(admin.ModelAdmin):
 
     @admin.action(description="Načíst/aktualizovat zápasy z webu (Playwright)")
     def sync_results_for_league(self, request: Any, queryset: Any) -> None:
-        """Fetch/update league matches using the custom management command."""
+        """Fetch and update league matches using the custom management command.
+
+        Args:
+            request: Current HTTP request.
+            queryset: Selected leagues; expects exactly one.
+
+        Returns:
+            None
+        """
         if queryset.count() != 1:
             self.message_user(request, "Vyber přesně jednu ligu.", level=messages.ERROR)
             return

--- a/powerplay_app/portal/views/calendar.py
+++ b/powerplay_app/portal/views/calendar.py
@@ -43,6 +43,9 @@ class CalendarView(TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # override
         """Provide event lists and a fallback game list.
 
+        Args:
+            **kwargs: Extra context kwargs passed by Django.
+
         Returns:
             Template context with keys ``primary_team``, ``events``,
             ``fallback_games``, and date range markers.

--- a/powerplay_app/portal/views/dashboard.py
+++ b/powerplay_app/portal/views/dashboard.py
@@ -26,6 +26,9 @@ class DashboardView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # override
         """Build minimal context required by the dashboard template.
 
+        Args:
+            **kwargs: Extra context kwargs passed by Django.
+
         Returns:
             Template context with ``current`` set to ``"dashboard"`` for
             active navigation highlighting.

--- a/powerplay_app/portal/views/feedback.py
+++ b/powerplay_app/portal/views/feedback.py
@@ -48,6 +48,9 @@ class FeedbackView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
         """Assemble list and form for the primary team.
 
+        Args:
+            **kwargs: Extra context kwargs passed by Django.
+
         Returns:
             Template context including ``primary_team``, ``items``, ``form``,
             optional range hints, and the current menu marker.
@@ -83,6 +86,11 @@ class FeedbackView(LoginRequiredMixin, TemplateView):
 
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Validate and create a feedback entry; preserve original UX.
+
+        Args:
+            request: Current HTTP request.
+            *args: Unused positional arguments.
+            **kwargs: Unused keyword arguments.
 
         Returns:
             Redirect back to the feedback page on success or team resolution

--- a/powerplay_app/portal/views/wallet.py
+++ b/powerplay_app/portal/views/wallet.py
@@ -81,6 +81,12 @@ class WalletView(LoginRequiredMixin, TemplateView):
     def _years_for_team(self, team: "Team" | None) -> list[int]:
         """Return all years with any transactions; fallback to current year.
 
+        Args:
+            team: Team to inspect or ``None``.
+
+        Returns:
+            list[int]: Available years for the filter dropdown.
+
         The query uses ``.dates('date', 'year')`` to keep it database-side, then
         extracts unique years for the filter dropdown.
         """
@@ -106,6 +112,12 @@ class WalletView(LoginRequiredMixin, TemplateView):
     # ---- view --------------------------------------------------------------
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
         """Assemble filter values, compute aggregates, and provide lists.
+
+        Args:
+            **kwargs: Extra context kwargs passed by Django.
+
+        Returns:
+            dict[str, Any]: Template context for the wallet view.
 
         Notes:
             - Keeps defaults stable even if there is no team yet.

--- a/powerplay_app/services/stats.py
+++ b/powerplay_app/services/stats.py
@@ -95,7 +95,14 @@ def player_season_totals_qs(team: Team) -> QuerySet[PlayerSeasonTotals]:
 
 
 def games_for_team(team: Team) -> QuerySet[Game]:
-    """Return all games where the team is home or away (select-related)."""
+    """Return games where the team is home or away.
+
+    Args:
+        team: Team whose games should be fetched.
+
+    Returns:
+        QuerySet[Game]: Games with related teams selected for performance.
+    """
     return (
         Game.objects.select_related("home_team", "away_team")
         .filter(Q(home_team=team) | Q(away_team=team))
@@ -104,6 +111,12 @@ def games_for_team(team: Team) -> QuerySet[Game]:
 
 def recompute_game(game: Game) -> None:
     """Recompute a game's score and per-player stats from atomic events.
+
+    Args:
+        game: Game instance to recompute.
+
+    Returns:
+        None
 
     What is recomputed:
         - Game score (from ``Goal`` events per team).

--- a/powerplay_app/services/team.py
+++ b/powerplay_app/services/team.py
@@ -2,8 +2,6 @@
 """Team-related service helpers.
 
 Internal documentation is in English; user-facing strings remain Czech.
-Behavior preserved: only Google-style docstrings, type hints, and light
-formatting were added.
 """
 
 from __future__ import annotations

--- a/powerplay_app/tests/test_pydocstyle.py
+++ b/powerplay_app/tests/test_pydocstyle.py
@@ -1,0 +1,27 @@
+"""Lint project docstrings with pydocstyle."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+
+@pytest.mark.skipif(
+    shutil.which("pydocstyle") is None, reason="pydocstyle is not installed"
+)
+def test_pydocstyle() -> None:
+    """Run pydocstyle on selected modules."""
+    result = subprocess.run(
+        [
+            "pydocstyle",
+            "powerplay_app/admin.py",
+            "powerplay_app/portal/views",
+            "powerplay_app/services",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 DJANGO_SETTINGS_MODULE = powerplay_manager.settings
 python_files = tests.py test_*.py *_tests.py
 addopts = -ra
+
+[pydocstyle]
+convention = google
+add-ignore = D104,D105,D107,D203,D212

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pillow==11.3.0
 psycopg2-binary==2.9.10
 pycodestyle==2.14.0
 pyflakes==3.4.0
+pydocstyle==6.3.0
 sqlparse==0.5.3
 ---------------------- --------
 asgiref                3.9.1


### PR DESCRIPTION
## Summary
- standardize docstrings to Google style across admin, portal views, and service modules
- add `pydocstyle` configuration and lint test
- include `pydocstyle` in project dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest powerplay_app/tests/test_pydocstyle.py` *(skipped: pydocstyle is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aca6466934833193b0cb3b3fe78b41