### PR TITLE
Document test data management commands

### DIFF
--- a/powerplay_app/management/commands/clear_test_data.py
+++ b/powerplay_app/management/commands/clear_test_data.py
@@ -1,3 +1,11 @@
+"""Remove all test data from the application's database.
+
+This management command irreversibly deletes objects used for local
+testing such as matches, players, teams, stadiums and competitions.
+**WARNING:** Running this command will permanently purge those records
+and should only be done in a non-production environment.
+"""
+
 from django.core.management.base import BaseCommand
 from powerplay_app.models import Match, Player, Team, Stadium, Competition
 
@@ -5,6 +13,14 @@ class Command(BaseCommand):
     help = "Vyčistí testovací data z databáze"
 
     def handle(self, *args, **kwargs):
+        """Execute the command.
+
+        No arguments are expected. The method sequentially deletes all
+        records for ``Match``, ``Player``, ``Team``, ``Stadium`` and
+        ``Competition`` models, then outputs a warning to ``stdout``.
+        This action cannot be undone and will empty the associated
+        tables.
+        """
         Match.objects.all().delete()
         Player.objects.all().delete()
         Team.objects.all().delete()

--- a/powerplay_app/management/commands/load_test_data.py
+++ b/powerplay_app/management/commands/load_test_data.py
@@ -1,3 +1,12 @@
+"""Populate the database with a full set of sample hockey data.
+
+The command is intended for development purposes: it wipes existing
+league, team and game objects and recreates them with realistic test
+records including lines, assignments, goals and penalties. **WARNING:**
+All existing data in these tables will be deleted before new entries
+are created.
+"""
+
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from datetime import date, datetime
@@ -12,6 +21,17 @@ class Command(BaseCommand):
     help = "Naplní databázi realistickými testovacími daty pro ligu, týmy, hráče a zápasy (včetně postů v lajnách)."
 
     def handle(self, *args, **options):
+        """Create deterministic test records for a demo league.
+
+        No positional arguments or options are required. The command
+        first purges existing related tables to avoid foreign-key
+        conflicts, then builds a small league with stadiums, teams,
+        players, scheduled games, line combinations and random events.
+        Progress messages are written to ``stdout`` and game statistics
+        are recomputed at the end. Running this command replaces any
+        existing data and should only be used in a disposable
+        environment.
+        """
         self.stdout.write("⚙️  Resetuji stávající testovací data…")
         # Smazat v bezpečném pořadí kvůli FK
         Goal.objects.all().delete()


### PR DESCRIPTION
## Summary
- explain destructive purpose of `clear_test_data` management command
- document data reset and creation flow in `load_test_data`
- add detailed `handle` method docstrings for both commands

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68aca64ffdc4833197d493bf489a6ec2