### PR TITLE
chore: remove unused stub views module

### DIFF
--- a/powerplay_app/views.py
+++ b/powerplay_app/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
## Summary
- remove unreferenced powerplay_app/views.py stub

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aca64e1d48833180f37116a815bf50