### PR TITLE
docs: expand service docstrings

### DIFF
--- a/powerplay_app/services/team.py
+++ b/powerplay_app/services/team.py
@@ -19,12 +19,22 @@ def get_primary_team() -> Optional[Team]:
 
     Resolution precedence:
         1. ``settings.PRIMARY_TEAM_ID`` – exact ID match.
-        2. ``settings.PRIMARY_TEAM_SLUG`` – case-insensitive match against ``Team.name``.
+        2. ``settings.PRIMARY_TEAM_SLUG`` – case-insensitive match against
+           ``Team.name``.
         3. Fallback: the first team by ``id`` (if any).
+
+    Args:
+        None.
 
     Returns:
         Optional[Team]: The resolved team instance, or ``None`` when no team
         exists in the database.
+
+    Side Effects:
+        Performs read-only database queries. No data is modified.
+
+    Raises:
+        None.
     """
     team: Optional[Team] = None
 


### PR DESCRIPTION
## Summary
- document player season totals query with arg types, returns, and side-effects
- add complete docstrings for team game listing and game recomputation helpers
- clarify primary team resolution behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install Django==5.2.5` *(fails: Could not find a version that satisfies the requirement Django==5.2.5 (ProxyError: Tunnel connection failed: 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68aca60de5f08331bac1942a8b72248f